### PR TITLE
feat: create input component and spec file

### DIFF
--- a/components/Input.tsx
+++ b/components/Input.tsx
@@ -1,0 +1,41 @@
+import React, { FunctionComponent, useState } from 'react'
+
+interface InputProps {
+  /**
+   * Input Placeholder
+   */
+  placeholder: string;
+  /**
+   * Type Placeholder
+   */
+  type: string;
+  /**
+   * Click handler
+   */
+  onChange?: () => void;
+}
+
+/**
+ * Input component for user interaction
+ */
+const Input: FunctionComponent<InputProps> = ({ placeholder, type, ...props }) => {
+  const [value, setValue] = useState('');
+
+  const handleChange = (event: { target: { value: React.SetStateAction<string>; }; }) => {
+    setValue(event.target.value);
+  };
+
+  return (
+    <input
+      type={type}
+      role="input"
+      data-cy="input"
+      placeholder={placeholder}
+      onChange={handleChange}
+      value={value}
+      className="border-solid border-2 border-primary-purple p-2 focus:border-primary-orange focus:outline-primary-orange focus:outline"
+    />
+  )
+}
+
+export default Input;

--- a/components/Input.tsx
+++ b/components/Input.tsx
@@ -6,7 +6,7 @@ interface InputProps {
    */
   placeholder: string;
   /**
-   * Type Placeholder
+   * Input type
    */
   type: string;
   /**

--- a/stories/Input.spec.js
+++ b/stories/Input.spec.js
@@ -1,0 +1,6 @@
+describe("General / Input", () => {
+    it("Default", () => {
+        cy.visit("/iframe.html?args=&id=general-input--primary")
+        cy.get('[data-cy="input"]').should('be.visible')
+    })
+})

--- a/stories/Input.stories.tsx
+++ b/stories/Input.stories.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+import Input from '../components/Input';
+
+// More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
+export default {
+  title: 'General/Input',
+  component: Input,
+} as ComponentMeta<typeof Input>;
+
+// More on component templates: https://storybook.js.org/docs/react/writing-stories/introduction#using-args
+const Template: ComponentStory<typeof Input> = (args) => <Input {...args} />;
+
+export const Primary = Template.bind({});
+// More on args: https://storybook.js.org/docs/react/writing-stories/args
+Primary.args = {
+  placeholder: 'Name',
+  type: 'text'
+};


### PR DESCRIPTION
Connected to

**File Created/updated:** Input.tsx

**Notes:**

Built the input component equivalent to the SW-32 feature (https://sharpy.atlassian.net/jira/software/projects/SW/boards/2?selectedIssue=SW-32). The component was built so that the type and placeholder are props passed to the component and the .spec file was created for testing. 

Below is what the input should look like and how it turned out:

* How it should appear:
![image](https://user-images.githubusercontent.com/47213156/206591477-ee3c731a-b8a5-46c9-a4e7-987fa63a0a84.png)

* How it turned out:
![image](https://user-images.githubusercontent.com/47213156/206591627-8640198f-eceb-4cb3-90be-e5e161c46eef.png)
![image](https://user-images.githubusercontent.com/47213156/206591662-a197f9c9-fd6e-462f-87b9-10ecfdc07613.png)

* Link to the design in Figma: https://www.figma.com/file/lVD8seuAhdZAjrkrwpoFyI/Sharpy?node-id=375%3A7266&t=Z5hSOEJqKXLxuyXq-0

**Checklist:**

- [ ] I added github label for semantic versioning
- [x] I double checked it looks like the designs
- [ ] I completed any required mobile breakpoint styling
- [x] I completed any required hover state styling
- [x] I included a working spec file
- [ ] I added notes above about how long it took to build this component
- [ ] UX has reviewed this PR
- [x] I assigned this PR to someone to review
